### PR TITLE
Fix dependencies in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ all: build install cleanall
 build: res src
 	zip -r $(PKGFILE) $(PKGDIR)
 
+$(PKGFILE): build
+
 install: $(PKGFILE)
 	kpackagetool6 -t KWin/Script -s $(NAME) \
 		&& kpackagetool6 -t KWin/Script -u $(PKGFILE) \


### PR DESCRIPTION
Add a rule to generate the pkgfile needed by some of the targets. This make the install target to automatically build the plugin.